### PR TITLE
Default translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Go Context Internationalization - translating apps easily.
 
 `ctxi18n` is heavily influenced by [internationalization in Ruby on Rails](https://guides.rubyonrails.org/i18n.html) and aims to make it just as straightforward in Go applications.
 
-As the name suggests, `ctxi18n` focusses on making i18n data available inside an application's context instances, but is sufficiently flexible to use directly if needed.
+As the name suggests, `ctxi18n` focusses on making i18n data available inside an application's context instances, but is sufficiently flexible to used directly if needed.
 
 Key Features:
 
@@ -22,6 +22,7 @@ Key Features:
 - Short method names like `i18n.T()` or `i18n.N()`.
 - Support for simple interpolation using keys, e.g. `Some %{key} text`
 - Support for pluralization rules.
+- Default values when translations are missing.
 
 ## Usage
 
@@ -102,6 +103,30 @@ fmt.Println(l.T("welcome.title"))
 
 There is no preferred way on how to use this library, so please use whatever best first your application and coding style. Sometimes it makes sense to pass in the context in every call, other times the code can be shorter and more concise by extracting it.
 
+### Defaults
+
+If a translation is missing from the locale a "missing" text will be produced, for example:
+
+```go
+fmt.Println(l.T("welcome.no.text"))
+```
+
+Will return a text that follows the `fmt.Sprintf` missing convention:
+
+```
+!(MISSING welcome.no.text)
+```
+
+This can be useful for translators to figure out which texts are missing, but sometimes a default value is more appropriate:
+
+```go
+fmt.Println(i18n.T(ctx, "welcome.question", i18n.Default("Just ask!")))
+// output: "Just ask!"
+code := "EUR"
+fmt.Println(i18n.T(ctx, "currencies."+code, i18n.Default(code)))
+// output: "EUR"
+```
+
 ### Interpolation
 
 Go's default approach for interpolation using the `fmt.Sprintf` and related methods is good for simple use-cases. For example, given the following translation:
@@ -131,6 +156,12 @@ i18n.T(ctx, "welcome.title", i18n.M{"name":"Sam"})
 ```
 
 The `i18n.M` map is used to perform a simple find and replace on the matching translation. The `fmt.Sprint` method is used to convert values into strings, so you don't need to worry about simple serialization like for numbers.
+
+Interpolation can also be used alongside default values:
+
+```go
+i18n.T(ctx, "welcome.title", i18n.Default("Hi %{name}"), i18n.M{"name":"Sam"})
+```
 
 ## Pluralization
 
@@ -187,7 +218,9 @@ package main
 import "github.com/invopop/ctxi18n/i18n"
 
 templ Hello(name string) {
-  <div>{ i18n.T(ctx, "welcome.hello", i18n.M{"name": name}) }</div>
+  <span class="hello">
+    { i18n.T(ctx, "welcome.hello", i18n.M{"name": name}) }
+  </span>
 }
 
 templ Greeting(person Person) {
@@ -197,8 +230,10 @@ templ Greeting(person Person) {
 }
 ```
 
+To save even more typing, it might be worth defining your own templ wrappers around those defined in the `i18n` package. Check out the [gobl.html `t` package](https://github.com/invopop/gobl.html/tree/main/components/t) for an example.
+
 # Examples
 
 The following is a list of Open Source projects using this library from which you can see working examples for your own solutions. Please send in a PR if you'd like to add your project!
 
-- [GOBL HTML](https://github.com/invopop/gobl.html) - generate HTML files from [GOBL](https://gobl.org) documents.
+- [GOBL HTML](https://github.com/invopop/gobl.html) - generate HTML files like invoices from [GOBL](https://gobl.org) documents.

--- a/i18n/dict.go
+++ b/i18n/dict.go
@@ -2,12 +2,7 @@ package i18n
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
-)
-
-const (
-	missingDictOut = "!(MISSING: %s)"
 )
 
 // Dict holds the internationalization entries for a specific locale.
@@ -41,17 +36,20 @@ func (d *Dict) Add(key string, value any) {
 	}
 }
 
-// Get provides the value from the dictionary at the provided key location.
-func (d *Dict) Get(key string) string {
-	entry := d.GetEntry(key)
-	if entry == nil {
-		return missing(key)
+// Value returns the dictionary value or an empty string
+// if the dictionary is nil.
+func (d *Dict) Value() string {
+	if d == nil {
+		return ""
 	}
-	return entry.value
+	return d.value
 }
 
-// GetEntry recursively retrieves the dictionary at the provided key location.
-func (d *Dict) GetEntry(key string) *Dict {
+// Get recursively retrieves the dictionary at the provided key location.
+func (d *Dict) Get(key string) *Dict {
+	if d == nil {
+		return nil
+	}
 	if key == "" {
 		return nil
 	}
@@ -63,7 +61,7 @@ func (d *Dict) GetEntry(key string) *Dict {
 	if len(n) == 1 {
 		return entry
 	}
-	return entry.GetEntry(n[1])
+	return entry.Get(n[1])
 }
 
 // Merge combines the entries of the second dictionary into this one.
@@ -94,8 +92,4 @@ func (d *Dict) UnmarshalJSON(data []byte) error {
 	}
 	d.entries = make(map[string]*Dict)
 	return json.Unmarshal(data, &d.entries)
-}
-
-func missing(key string) string {
-	return fmt.Sprintf(missingDictOut, key)
 }

--- a/i18n/dict_test.go
+++ b/i18n/dict_test.go
@@ -23,30 +23,31 @@ func TestDictUnmarshalJSON(t *testing.T) {
 	dict := new(Dict)
 	err := json.Unmarshal([]byte(ex), dict)
 	require.NoError(t, err)
-	assert.Equal(t, "bar", dict.Get("foo"))
-	assert.Equal(t, "quux", dict.Get("baz.qux"))
-	assert.Equal(t, "", dict.Get("baz.plural"))
-	assert.Equal(t, "!(MISSING: random)", dict.Get("random"))
+	assert.Equal(t, "bar", dict.Get("foo").Value())
+	assert.Equal(t, "quux", dict.Get("baz.qux").Value())
+	assert.Empty(t, dict.Get("baz.plural").Value())
+	assert.Empty(t, dict.Get("random").Value())
 }
 
 func TestDictAdd(t *testing.T) {
 	d := NewDict()
+	assert.Nil(t, d.Get(""))
 	d.Add("foo", "bar")
-	assert.Equal(t, "bar", d.Get("foo"))
+	assert.Equal(t, "bar", d.Get("foo").Value())
 
 	d.Add("plural", map[string]any{
 		"zero":  "no mice",
 		"one":   "%s mouse",
 		"other": "%s mice",
 	})
-	assert.Equal(t, "no mice", d.Get("plural.zero"))
-	assert.Equal(t, "%s mice", d.Get("plural.other"))
+	assert.Equal(t, "no mice", d.Get("plural.zero").Value())
+	assert.Equal(t, "%s mice", d.Get("plural.other").Value())
 
 	d.Add("bad", 10) // ignore
-	assert.Equal(t, "!(MISSING: bad)", d.Get("bad"))
+	assert.Nil(t, d.Get("bad"))
 
 	d.Add("self", d)
-	assert.Equal(t, "bar", d.Get("self.foo"))
+	assert.Equal(t, "bar", d.Get("self.foo").Value())
 }
 
 func TestDictMerge(t *testing.T) {
@@ -74,9 +75,9 @@ func TestDictMerge(t *testing.T) {
 
 	d3 := new(Dict)
 	d3.Merge(d2)
-	assert.Equal(t, "value", d3.Get("extra"))
+	assert.Equal(t, "value", d3.Get("extra").Value())
 
 	d1.Merge(d2)
-	assert.Equal(t, "bar", d1.Get("foo"))
-	assert.Equal(t, "value", d1.Get("extra"))
+	assert.Equal(t, "bar", d1.Get("foo").Value())
+	assert.Equal(t, "value", d1.Get("extra").Value())
 }

--- a/i18n/locale_test.go
+++ b/i18n/locale_test.go
@@ -20,10 +20,16 @@ func TestLocaleGet(t *testing.T) {
 
 	assert.Equal(t, "bar", l.T("foo"))
 	assert.Equal(t, "quux", l.T("baz.qux"))
+	assert.Equal(t, "!(MISSING: baz.random)", l.T("baz.random"))
 	assert.Equal(t, "no mice", l.N("baz.mice", 0, i18n.M{"count": 0}))
 	assert.Equal(t, "1 mouse", l.N("baz.mice", 1, i18n.M{"count": 1}))
 	assert.Equal(t, "2 mice", l.N("baz.mice", 2, i18n.M{"count": 2}))
 	assert.Equal(t, "!(MISSING: random)", l.N("random", 2))
+
+	assert.Equal(t, "xyz", l.T("random", i18n.Default("xyz")))
+	assert.Equal(t, "xyz test", l.T("random", i18n.Default("xyz %{foo}"), i18n.M{"foo": "test"}))
+	assert.Equal(t, "xyz test", l.T("random", i18n.M{"foo": "test"}, i18n.Default("xyz %{foo}")))
+	assert.Equal(t, "2 mouses", l.N("baz.random", 2, i18n.Default("%{count} mouses"), i18n.M{"count": 2}))
 }
 
 func TestLocaleInterpolate(t *testing.T) {

--- a/i18n/plural_rules.go
+++ b/i18n/plural_rules.go
@@ -5,6 +5,10 @@ const (
 	DefaultRuleKey = "default"
 )
 
+// PluralRule defines a simple method that expects a dictionary and number and
+// will find a matching dictionary entry.
+type PluralRule func(d *Dict, num int) *Dict
+
 const (
 	zeroKey  = "zero"
 	oneKey   = "one"
@@ -13,11 +17,11 @@ const (
 
 var rules = map[string]PluralRule{
 	// Most languages can use this rule
-	DefaultRuleKey: func(d *Dict, n int) string {
+	DefaultRuleKey: func(d *Dict, n int) *Dict {
 		if n == 0 {
-			v := d.GetEntry(zeroKey)
+			v := d.Get(zeroKey)
 			if v != nil {
-				return v.value
+				return v
 			}
 		}
 		if n == 1 {

--- a/i18n/plural_rules_test.go
+++ b/i18n/plural_rules_test.go
@@ -16,9 +16,9 @@ func TestZeroOneOtherRule(t *testing.T) {
 	}
 	rule := GetRule(DefaultRuleKey)
 	assert.NotNil(t, rule)
-	assert.Equal(t, "no mice", rule(d, 0))
-	assert.Equal(t, "%{count} mouse", rule(d, 1))
-	assert.Equal(t, "%{count} mice", rule(d, 2))
+	assert.Equal(t, "no mice", rule(d, 0).Value())
+	assert.Equal(t, "%{count} mouse", rule(d, 1).Value())
+	assert.Equal(t, "%{count} mice", rule(d, 2).Value())
 
 	d = &Dict{
 		entries: map[string]*Dict{
@@ -26,7 +26,7 @@ func TestZeroOneOtherRule(t *testing.T) {
 			"other": {value: "%{count} mice"},
 		},
 	}
-	assert.Equal(t, "%{count} mice", rule(d, 0))
-	assert.Equal(t, "%{count} mouse", rule(d, 1))
-	assert.Equal(t, "%{count} mice", rule(d, 2))
+	assert.Equal(t, "%{count} mice", rule(d, 0).Value())
+	assert.Equal(t, "%{count} mouse", rule(d, 1).Value())
+	assert.Equal(t, "%{count} mice", rule(d, 2).Value())
 }


### PR DESCRIPTION
* adds support for a `i18n.Default("txt")` argument to the key translation methods
* includes a small refactor of the `Dict` struct to always provide sub-dictionaries instead of texts.
* missing handling moved to the locale object and interpolation.