### PR TITLE
Loading locales with a default fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ if err := ctxi18n.Load(assets.Content); err != nil {
 }
 ```
 
+If you'd like to set a default base language to try to use for any missing translations, load the assets with a default:
+
+```go
+if err := ctxi18n.LoadWithDefault(assets.Content, "en"); err != nil {
+    panic(err)
+}
+```
+
 You'll now have a global set of locales prepared in memory and ready to use. Assuming your application uses some kind of context such as from an HTTP or gRPC request, you'll want to add a single locale to it:
 
 ```go

--- a/i18n/dict.go
+++ b/i18n/dict.go
@@ -64,7 +64,8 @@ func (d *Dict) Get(key string) *Dict {
 	return entry.Get(n[1])
 }
 
-// Merge combines the entries of the second dictionary into this one.
+// Merge combines the entries of the second dictionary into this one. If a
+// key is duplicated in the second diction, the original value takes priority.
 func (d *Dict) Merge(d2 *Dict) {
 	if d2 == nil {
 		return

--- a/i18n/dict_test.go
+++ b/i18n/dict_test.go
@@ -66,6 +66,7 @@ func TestDictMerge(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(ex), d1))
 
 	ex2 := `{
+		"foo": "baz",
 		"extra": "value"
 	}`
 	d2 := new(Dict)
@@ -78,6 +79,6 @@ func TestDictMerge(t *testing.T) {
 	assert.Equal(t, "value", d3.Get("extra").Value())
 
 	d1.Merge(d2)
-	assert.Equal(t, "bar", d1.Get("foo").Value())
+	assert.Equal(t, "bar", d1.Get("foo").Value(), "should not overwrite")
 	assert.Equal(t, "value", d1.Get("extra").Value())
 }

--- a/i18n/locales.go
+++ b/i18n/locales.go
@@ -42,6 +42,28 @@ func (ls *Locales) Load(src fs.FS) error {
 	})
 }
 
+// LoadWithDefault performs the regular load operation, but follows up with
+// a second operation that will ensure that default dictionary is merged with
+// every other locale, thus ensuring that every text will have a fallback.
+func (ls *Locales) LoadWithDefault(src fs.FS, locale Code) error {
+	if err := ls.Load(src); err != nil {
+		return err
+	}
+
+	l := ls.Get(locale)
+	if l == nil {
+		return fmt.Errorf("undefined default locale: %s", locale)
+	}
+	for _, loc := range ls.list {
+		if loc == l {
+			continue
+		}
+		loc.dict.Merge(l.dict)
+	}
+
+	return nil
+}
+
 // Get provides the define Locale object for the matching key.
 func (ls *Locales) Get(code Code) *Locale {
 	for _, loc := range ls.list {

--- a/i18n/locales_test.go
+++ b/i18n/locales_test.go
@@ -28,12 +28,39 @@ func TestLocalesLoad(t *testing.T) {
 	l := ls.Match("en-US,en;q=0.9,es;q=0.8")
 	require.NotNil(t, l)
 	assert.Equal(t, "en", l.Code().String())
+	assert.Equal(t, "Log In", l.T("login.button"))
+	assert.Equal(t, "Special Label", l.T("special_label"))
 
 	l = ls.Match("es-ES,es;q=0.9,en;q=0.8")
 	require.NotNil(t, l)
 	assert.Equal(t, "es", l.Code().String())
+	assert.Equal(t, "Iniciar Sesión", l.T("login.button"))
+	assert.Equal(t, "!(MISSING: special_label)", l.T("special_label"))
 
 	assert.Nil(t, ls.Match("inv"))
+}
+
+func TestLoadWithDefault(t *testing.T) {
+	ls := new(i18n.Locales)
+	err := ls.LoadWithDefault(examples.Content, "en")
+	require.NoError(t, err)
+
+	l := ls.Match("en")
+	require.NotNil(t, l)
+	assert.Equal(t, "en", l.Code().String())
+	assert.Equal(t, "Log In", l.T("login.button"))
+	assert.Equal(t, "Special Label", l.T("special_label"))
+
+	l = ls.Match("es")
+	require.NotNil(t, l)
+	assert.Equal(t, "es", l.Code().String())
+	assert.Equal(t, "Iniciar Sesión", l.T("login.button"))
+	assert.Equal(t, "Special Label", l.T("special_label"))
+
+	ls = new(i18n.Locales)
+	err = ls.LoadWithDefault(examples.Content, "bad")
+	assert.ErrorContains(t, err, "undefined default locale: bad")
+
 }
 
 func TestLocalesUnmarshalJSON(t *testing.T) {

--- a/internal/examples/en/en.yaml
+++ b/internal/examples/en/en.yaml
@@ -8,3 +8,4 @@ en:
   about_us: "About Us"
   terms_of_service: "Terms of Service"
   privacy_policy: "Privacy Policy"
+  special_label: "Special Label"


### PR DESCRIPTION
* `LoadWithDefault` method will attempt to merge the default language with all other locales so that there are no missing translations.