### PR TITLE
Allow empty string to be a valid value

### DIFF
--- a/i18n/locale.go
+++ b/i18n/locale.go
@@ -97,12 +97,13 @@ func GetLocale(ctx context.Context) *Locale {
 
 func interpolate(key string, d *Dict, args ...any) string {
 	var s string
-	s, args = extractDefault(args)
+	var hasDefault bool
+	s, args, hasDefault = extractDefault(args)
+	if !hasDefault && d == nil {
+		return missing(key)
+	}
 	if d != nil {
 		s = d.value
-	}
-	if s == "" {
-		return missing(key)
 	}
 	if len(args) > 0 {
 		switch arg := args[0].(type) {
@@ -115,13 +116,13 @@ func interpolate(key string, d *Dict, args ...any) string {
 	return s
 }
 
-func extractDefault(args []any) (string, []any) {
+func extractDefault(args []any) (string, []any, bool) {
 	for i, arg := range args {
 		if dt, ok := arg.(DefaultText); ok {
-			return string(dt), append(args[:i], args[i+1:]...)
+			return string(dt), append(args[:i], args[i+1:]...), true
 		}
 	}
-	return "", args
+	return "", args, false
 }
 
 func missing(key string) string {

--- a/i18n/locale_test.go
+++ b/i18n/locale_test.go
@@ -39,6 +39,7 @@ func TestLocaleHas(t *testing.T) {
 
 	assert.True(t, l.Has("foo"))
 	assert.True(t, l.Has("baz.qux"))
+	assert.True(t, l.Has("empty"))
 	assert.False(t, l.Has("baz.random"))
 }
 
@@ -48,6 +49,8 @@ func TestLocaleInterpolate(t *testing.T) {
 
 	out := l.N("baz.ducks", 1, 1)
 	assert.Equal(t, "1 duck", out)
+	assert.Equal(t, "", l.N("baz.ducks", 0))
+	assert.Equal(t, "", l.T("empty"))
 }
 
 func TestLocalWithContext(t *testing.T) {
@@ -92,9 +95,11 @@ func SampleLocaleData() []byte {
 				"other": "%{count} mice"
 			},
 			"ducks": {
+				"zero": "",
 				"one": "%d duck",
 				"other": "%d ducks"
 			}
-		}
+		},
+        "empty": ""
 	}`)
 }


### PR DESCRIPTION
If a user passes a key with an empty value to the translation files, I believe we should consider that intentional, instead of assuming any empty string to be a key with a missing value